### PR TITLE
chore: expancion multiplataforma

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,331 @@
+name: Build & Commit Installers
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: 'installers'
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+  issues: write
+
+jobs:
+  resolve:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version_tag: ${{ steps.version.outputs.version_tag }}
+      version_no_v: ${{ steps.version.outputs.version_no_v }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version tag
+        id: version
+        run: |
+          git fetch --tags --force
+          VERSION_TAG=$(git tag --list "v*" --sort=-v:refname | head -n 1)
+          if [ -z "$VERSION_TAG" ]; then
+            VERSION_TAG="v0.0.1"
+          fi
+          VERSION_NO_V=${VERSION_TAG#v}
+          echo "version_tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version_no_v=${VERSION_NO_V}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version tag: $VERSION_TAG"
+
+  linux:
+    name: Build Linux (.deb / .rpm / .AppImage)
+    runs-on: ubuntu-latest
+    needs: resolve
+    env:
+      VERSION_NO_V: ${{ needs.resolve.outputs.version_no_v }}
+      PUBLIC_SHOW_DEV_TOOLS: ${{ vars.PUBLIC_SHOW_DEV_TOOLS }}
+      PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+      PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+      PUBLIC_ROLLUP_VISUALIZER: ${{ vars.PUBLIC_ROLLUP_VISUALIZER }}
+      PUBLIC_RAMOLIBRE_LAB_URL: ${{ vars.PUBLIC_RAMOLIBRE_LAB_URL }}
+      PUBLIC_CLOUD_SYNC_POLL_INTERVAL: ${{ vars.PUBLIC_CLOUD_SYNC_POLL_INTERVAL }}
+      PUBLIC_TAURI_BUILD: 'true'
+      NO_STRIP: 'true'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update version files
+        run: bun scripts/update-version.js "$VERSION_NO_V"
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+
+      - name: Cache Tauri tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/tauri
+          key: tauri-tools-linux-${{ runner.os }}
+
+      - name: Build Tauri bundles
+        run: bun tauri build
+
+      - name: Rename bundles
+        run: |
+          set -euo pipefail
+          BUNDLE_DIR="src-tauri/target/release/bundle"
+          cp "$BUNDLE_DIR"/deb/*.deb "ramolibre_${VERSION_NO_V}_amd64.deb"
+          cp "$BUNDLE_DIR"/rpm/*.rpm "ramolibre-${VERSION_NO_V}-1.x86_64.rpm"
+          cp "$BUNDLE_DIR"/appimage/*.AppImage "ramolibre_${VERSION_NO_V}_amd64.AppImage"
+          ls -lh ramolibre_* ramolibre-*
+
+      - name: Upload Linux installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-installers
+          path: |
+            ramolibre_*.deb
+            ramolibre-*.rpm
+            ramolibre_*.AppImage
+          if-no-files-found: error
+
+  windows:
+    name: Build Windows (.msi)
+    runs-on: windows-latest
+    needs: resolve
+    env:
+      VERSION_NO_V: ${{ needs.resolve.outputs.version_no_v }}
+      PUBLIC_SHOW_DEV_TOOLS: ${{ vars.PUBLIC_SHOW_DEV_TOOLS }}
+      PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+      PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+      PUBLIC_ROLLUP_VISUALIZER: ${{ vars.PUBLIC_ROLLUP_VISUALIZER }}
+      PUBLIC_RAMOLIBRE_LAB_URL: ${{ vars.PUBLIC_RAMOLIBRE_LAB_URL }}
+      PUBLIC_CLOUD_SYNC_POLL_INTERVAL: ${{ vars.PUBLIC_CLOUD_SYNC_POLL_INTERVAL }}
+      PUBLIC_TAURI_BUILD: 'true'
+      NO_STRIP: 'true'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update version files
+        shell: pwsh
+        run: bun scripts/update-version.js "$env:VERSION_NO_V"
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+
+      - name: Get Tauri tools path
+        id: tools
+        shell: pwsh
+        run: |
+          $tools = Join-Path $env:LOCALAPPDATA 'tauri'
+          "path=$tools" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Cache Tauri tools
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.tools.outputs.path }}
+          key: tauri-tools-windows-${{ runner.os }}
+
+      - name: Build MSI
+        shell: pwsh
+        run: bun tauri build --bundles msi
+
+      - name: Rename MSI
+        shell: pwsh
+        run: |
+          $msi = Get-ChildItem -Path 'src-tauri/target/release/bundle' -Recurse -Filter '*.msi' | Select-Object -First 1
+          if (-not $msi) { throw 'MSI bundle not found' }
+          Copy-Item -Path $msi.FullName -Destination "ramolibre_$env:VERSION_NO_V_x64.msi"
+          Get-ChildItem -Filter 'ramolibre_*.msi'
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installers
+          path: ramolibre_*.msi
+          if-no-files-found: error
+
+  android:
+    name: Build Android (.apk)
+    runs-on: ubuntu-latest
+    needs: resolve
+    env:
+      VERSION_NO_V: ${{ needs.resolve.outputs.version_no_v }}
+      PUBLIC_SHOW_DEV_TOOLS: ${{ vars.PUBLIC_SHOW_DEV_TOOLS }}
+      PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+      PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+      PUBLIC_ROLLUP_VISUALIZER: ${{ vars.PUBLIC_ROLLUP_VISUALIZER }}
+      PUBLIC_RAMOLIBRE_LAB_URL: ${{ vars.PUBLIC_RAMOLIBRE_LAB_URL }}
+      PUBLIC_CLOUD_SYNC_POLL_INTERVAL: ${{ vars.PUBLIC_CLOUD_SYNC_POLL_INTERVAL }}
+      PUBLIC_TAURI_BUILD: 'true'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r27c
+
+      - name: Update version files
+        run: bun scripts/update-version.js "$VERSION_NO_V"
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+
+      - name: Reconstruct Keystore from Secret
+        run: |
+          mkdir -p android/app
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/my-release-key.jks
+
+      - name: Build APK with Tauri
+        run: bun tauri android build --apk
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }}
+
+      - name: Sign APK with apksigner
+        run: |
+          $ANDROID_HOME/build-tools/35.0.0/apksigner sign \
+            --ks android/app/my-release-key.jks \
+            --ks-pass pass:${{ secrets.ANDROID_KEYSTORE_PASSWORD }} \
+            --key-pass pass:${{ secrets.ANDROID_KEY_PASSWORD }} \
+            --ks-key-alias ${{ secrets.ANDROID_KEY_ALIAS }} \
+            --out ramolibre_${VERSION_NO_V}.apk \
+            src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk
+
+      - name: Check APK size
+        run: |
+          set -euo pipefail
+          APK="ramolibre_${VERSION_NO_V}.apk"
+          SIZE_MB=$(du -m "$APK" | cut -f1)
+          echo "APK size: ${SIZE_MB}MB"
+          if [ "$SIZE_MB" -ge 95 ]; then
+            echo "::warning title=APK size limit::APK is ${SIZE_MB}MB, near the 100MB GitHub file limit"
+            TITLE="APK size near the 100MB GitHub limit"
+            if [ -z "$(gh issue list -R ${{ github.repository }} --search "$TITLE" --state open --json number -q '.[0].number')" ]; then
+              BODY_FILE=$(mktemp)
+              cat > "$BODY_FILE" <<EOF
+          El APK generado en el workflow de instaladores pesa ${SIZE_MB}MB (limite de GitHub: 100MB por archivo).
+
+          Version: v${VERSION_NO_V}
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          Revisar reduccion de tamano o division por ABI antes de superar el limite.
+          EOF
+              gh issue create -R ${{ github.repository }} --title "$TITLE" --body-file "$BODY_FILE"
+              rm -f "$BODY_FILE"
+            fi
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Upload Android installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-installers
+          path: ramolibre_*.apk
+          if-no-files-found: error
+
+  commit:
+    name: Commit installers to 'artifacts' branch
+    runs-on: ubuntu-latest
+    needs: [resolve, linux, windows, android]
+    env:
+      VERSION_NO_V: ${{ needs.resolve.outputs.version_no_v }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare artifacts branch
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin artifacts >/dev/null 2>&1 || true
+          if git rev-parse --verify origin/artifacts >/dev/null 2>&1; then
+            git checkout -B artifacts origin/artifacts
+          else
+            git checkout --orphan artifacts
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+          git clean -fdxq >/dev/null 2>&1 || true
+
+      - name: Download installers
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Stage installers
+        run: |
+          set -euo pipefail
+          rm -f ramolibre_*.deb ramolibre-*.rpm ramolibre_*.AppImage ramolibre_*.msi ramolibre_*.apk ramolibre_latest*
+          cp dist/*.deb dist/*.rpm dist/*.AppImage dist/*.msi dist/*.apk ./
+          cp ramolibre_${VERSION_NO_V}_amd64.deb "ramolibre_latest_amd64.deb"
+          cp "ramolibre-${VERSION_NO_V}-1.x86_64.rpm" "ramolibre_latest-1.x86_64.rpm"
+          cp ramolibre_${VERSION_NO_V}_amd64.AppImage "ramolibre_latest_amd64.AppImage"
+          cp ramolibre_${VERSION_NO_V}_x64.msi "ramolibre_latest_x64.msi"
+          cp ramolibre_${VERSION_NO_V}.apk "ramolibre_latest.apk"
+          ls -lh ramolibre_* ramolibre-*
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          cat > README.md <<'EOF'
+          # Ramo Libre - Installers
+
+          Instaladores generados por el workflow [build-artifacts.yml](https://github.com/Ramo-Libre/Web/blob/main/.github/workflows/build-artifacts.yml).
+
+          Ultima version generada (sin version en la URL):
+
+          - `ramolibre_latest_amd64.deb`
+          - `ramolibre_latest-1.x86_64.rpm`
+          - `ramolibre_latest_amd64.AppImage`
+          - `ramolibre_latest_x64.msi`
+          - `ramolibre_latest.apk`
+
+          Descarga: `https://raw.githubusercontent.com/Ramo-Libre/Web/artifacts/<archivo>`
+          EOF
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(artifacts): add installers v${VERSION_NO_V} [skip ci]"
+            git push origin artifacts
+          fi

--- a/README.md
+++ b/README.md
@@ -30,11 +30,27 @@ Este proyecto está abierto a ideas, sugerencias y contribuciones.
 
 ## Tabla de contenidos
 
+- [Filosofía de diseño](#filosofía-de-diseño)
 - [Funcionalidades](#funcionalidades)
 - [Descargas](#descargas)
 - [Quick start](#quick-start)
 - [Créditos y atribuciones](#créditos-y-atribuciones)
 - [Licencia](#licencia)
+
+
+## Filosofía de diseño
+
+Ramo Libre Web no busca ser una suite de gestión académica exhaustiva, sino una herramienta de seguimiento: se usa para agregar algo cuando surge y dar un vistazo día a día, no para pasar tiempo dentro de la app. Toda decisión sobre qué agregar o cómo diseñarlo se evalúa contra los siguientes criterios:
+
+1. **Independencia.** Cada feature debe poder existir sin depender de las demás. Por debajo, las únicas features reales son *Schedule* (Horarios y Eventos son dos vistas de la misma feature) y *Escenarios*; no se tocan entre sí. Ramos es la única excepción consciente, ya que existe específicamente para organizar los datos del resto en categorías.
+
+2. **Valor real al día a día.** Toda feature debe resolver algo que efectivamente ocurre en el semestre a semestre de un estudiante, consultado de forma pasiva y breve — no gestión activa ni sesiones largas de uso.
+
+3. **Simplicidad.** La interacción hacia afuera debe ser trivial, incluso cuando el problema que resuelve por dentro no lo sea (es el caso de los Escenarios de Notas: un DSL expresivo por dentro, pero de uso trivial por fuera — se ingresan las reglas una vez y después solo se completan notas a medida que se conocen).
+
+4. **Alcance acotado.** Lo que no es gestión académica del día a día no entra a esta app, aunque esté relacionado. Casos de uso distintos —como simular combinaciones de notas con sliders— se resuelven en herramientas separadas del ecosistema Ramo Libre, no como una sección más de esta.
+
+5. **Nada "por si acaso".** Ninguna feature, campo o configuración se agrega por intuición o margen especulativo. Si no hay una razón concreta y verificable para incluir algo, no se incluye — y ante la duda, se prefiere omitir antes que sobrecargar.
 
 ## Funcionalidades
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Este proyecto está abierto a ideas, sugerencias y contribuciones.
 ## Tabla de contenidos
 
 - [Funcionalidades](#funcionalidades)
+- [Descargas](#descargas)
 - [Quick start](#quick-start)
 - [Créditos y atribuciones](#créditos-y-atribuciones)
 - [Licencia](#licencia)
@@ -48,6 +49,36 @@ Cada semestre mantiene su propia copia de los datos, organizados en las siguient
 - **Configuración** — ajusta el tema y las preferencias de visualización por semestre.
 
 Al eliminar un ramo se eliminan también sus horarios, escenarios de nota y pendientes vinculados. Cambiar de semestre activo cambia el conjunto completo de datos visible.
+
+## Descargas
+
+Los instaladores multiplataforma se generan manualmente con el workflow [`Build & Commit Installers`](.github/workflows/build-artifacts.yml) de GitHub Actions (trigger `workflow_dispatch`, nunca automático) y quedan disponibles en la rama [`artifacts`](https://github.com/Ramo-Libre/Web/tree/artifacts). Cada artefacto usa como versión el último tag publicado por el proceso de versionado semántico.
+
+### Descarga directa (última versión)
+
+Los enlaces apuntan siempre al último build generado, sin necesidad de conocer el número de versión:
+
+- **Linux (Debian):** [`ramolibre_latest_amd64.deb`](https://raw.githubusercontent.com/Ramo-Libre/Web/artifacts/ramolibre_latest_amd64.deb)
+- **Linux (Red Hat):** [`ramolibre_latest-1.x86_64.rpm`](https://raw.githubusercontent.com/Ramo-Libre/Web/artifacts/ramolibre_latest-1.x86_64.rpm)
+- **Linux (AppImage):** [`ramolibre_latest_amd64.AppImage`](https://raw.githubusercontent.com/Ramo-Libre/Web/artifacts/ramolibre_latest_amd64.AppImage)
+- **Windows (MSI):** [`ramolibre_latest_x64.msi`](https://raw.githubusercontent.com/Ramo-Libre/Web/artifacts/ramolibre_latest_x64.msi)
+- **Android (APK):** [`ramolibre_latest.apk`](https://raw.githubusercontent.com/Ramo-Libre/Web/artifacts/ramolibre_latest.apk)
+
+### Convención de nombres
+
+Los archivos con versión (`ramolibre_<version>_amd64.deb`, etc.) también quedan publicados en la misma rama:
+
+| Plataforma | Formato | Archivo |
+| --- | --- | --- |
+| Linux | Debian (`.deb`) | `ramolibre_<version>_amd64.deb` |
+| Linux | Red Hat (`.rpm`) | `ramolibre-<version>-1.x86_64.rpm` |
+| Linux | AppImage | `ramolibre_<version>_amd64.AppImage` |
+| Windows | Instalador MSI | `ramolibre_<version>_x64.msi` |
+| Android | APK | `ramolibre_<version>.apk` |
+
+> [!NOTE]
+> - El instalador de Windows (`.msi`) no está firmado con firma de código, por lo que Windows SmartScreen puede mostrar una advertencia al instalarlo.
+> - El paquete de AUR (`ramolibre`) no usa estos artefactos: se compila desde el código fuente del tag correspondiente mediante un proceso manual separado.
 
 ## Quick start
 


### PR DESCRIPTION
## Issue

Closes #93 

## Estado de las Tareas

- [x] Crear workflow nuevo con trigger `workflow_dispatch` (sin disparo automático por push/tag/release).
- [x] Al ejecutarse, obtener el tag de la versión más reciente del repo (`git describe --tags` o equivalente) para usarlo como versión del build.
- [x] Build Linux: `.deb`, `.rpm`, `.AppImage` (via `tauri-bundler`).
- [x] Build Windows: `.msi`.
- [x] Build Android: `.apk` (Tauri Mobile).
- [x] Commitear los artefactos generados al repo (rama/carpeta destino a definir) con `[skip ci]` en el mensaje, para que ese commit no dispare ningún otro workflow.
- [x] Verificar que los nombres de archivo generados sean consistentes con lo documentado en el README (`ramolibre_<version>_amd64.deb`, etc.).
- [x] Confirmar que el workflow no interfiere ni se dispara a partir del workflow de release semántico existente (y viceversa).
